### PR TITLE
Fix server module import error

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
-const express = require('express');
-const session = require('express-session');
-const { google } = require('googleapis');
+import express from 'express';
+import session from 'express-session';
+import { google } from 'googleapis';
 
 const app = express();
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- convert `server.js` to use ES module imports so it works with `type: module`

## Testing
- `npm install`
- `npm run server`

------
https://chatgpt.com/codex/tasks/task_e_684461b595788324bac44d1152299c99